### PR TITLE
fix: remove grid-col-2

### DIFF
--- a/styles/layouts.css
+++ b/styles/layouts.css
@@ -106,10 +106,6 @@
   }
 }
 
-.grid-cols-2 {
-  grid-template-columns: 6fr 4fr !important;
-}
-
 #slide-content p {
   line-height: 1.5em !important;
   font-size: 1em !important;


### PR DESCRIPTION
I'm not sure why this style was created, but it works weirdly (see image below) when dealing with `two-cols` layout.

![image](https://user-images.githubusercontent.com/26234614/161146038-aee4b618-ea49-40a3-8c4b-17a8dcd88a44.png)