### PR TITLE
chore: migrate to OIDC publishing for npm releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   release:
+    environment: production
     permissions:
       contents: write
       issues: write
@@ -25,12 +26,5 @@ jobs:
     steps:
       - uses: nearform-actions/optic-release-automation-action@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           semver: ${{ github.event.inputs.semver }}
-          npm-token: >-
-            ${{ secrets[format('NPM_TOKEN_{0}', github.actor)] ||
-            secrets.NPM_TOKEN }}
-          optic-token: >-
-            ${{ secrets[format('OPTIC_TOKEN_{0}', github.actor)] ||
-            secrets.OPTIC_TOKEN }}
-          provenance: true
+          publish-mode: oidc


### PR DESCRIPTION
- Add OIDC trusted publishing support
- Remove npm token and github-token dependencies
- Add production environment and required permissions
- Update to publish-mode: oidc

This migration eliminates the need for npm tokens and provides enhanced security through GitHub's identity provider.